### PR TITLE
Combat covar check

### DIFF
--- a/R/checkBatchEffects.R
+++ b/R/checkBatchEffects.R
@@ -79,6 +79,8 @@ check1 <- venn3(goodind,
 # str(check1)
 stopifnot(length(c(check1$q2, check1$q4, check1$q5, check1$q6, check1$q7, check1$q3)) == 0)
 
+# i might have to remove check1$q4 in case samples with NAs in the covariates get removed during ComBat
+
 ## ----AnnotationCombatCheck-----------------------------------------------
 ht(pData(total_nobkgd_eset_ql_combat), 2)
 total_nobkgd_eset_ql_combat

--- a/R/checkBatchEffects.R
+++ b/R/checkBatchEffects.R
@@ -77,7 +77,12 @@ check1 <- venn3(goodind,
                 pData(total_nobkgd_eset_ql)$sampleID,
                 pData(total_nobkgd_eset_ql_combat)$sampleID, plotte = showVennplots)
 # str(check1)
-stopifnot(length(c(check1$q2, check1$q4, check1$q5, check1$q6, check1$q7, check1$q3)) == 0)
+# removed check1$q6 from this, which is the overlap of samples pre and post combat - which does not have to be 0
+stopifnot(length(c(check1$q2, check1$q4, check1$q5,  check1$q7, check1$q3)) == 0)
+
+# Its no longer valid to compare sample size before/after combat due to removal of IDs... check on other ways to successfully check this
+# venn2(ht12object$chipsamples[ht12object$chipsamples$in_study==F, "new_ID"],
+# check1$q6)
 
 # i might have to remove check1$q4 in case samples with NAs in the covariates get removed during ComBat
 

--- a/R/removeBatchEffects.R
+++ b/R/removeBatchEffects.R
@@ -458,9 +458,12 @@ removeBatchEffects = function(ht12object,
   ht12object$genesdetail = genesdetail
 
   # individuenattrib
+  sample_overview_l7[sample_overview_l7$in_study & !(sample_overview_l7$new_ID %in% good.ids), ]$reason4exclusion <- "tmp"
+  sample_overview_l7[!(sample_overview_l7$new_ID %in% good.ids),"in_study"] = F
 
-  sample_overview_l7[!(sample_overview_l7$new_ID %in% good.ids),"in_study"] = F #TAG#
-  sample_overview_l7[!(sample_overview_l7$new_ID %in% good.ids),"reason4exclusion"] <- "Missings in covariate data. This is not allowed with batch adjustment via ComBat()"
+  # don't overwrite the other reason4exclusions
+  sample_overview_l7[sample_overview_l7$reason4exclusion %in% "tmp" ,"reason4exclusion"] <- "Missings in covariate data. This is not allowed with batch adjustment via ComBat()"
+  # sample_overview_l7[!(sample_overview_l7$new_ID %in% good.ids),"reason4exclusion"] <- "Missings in covariate data. This is not allowed with batch adjustment via ComBat()"
   sample_overview_l7[sample_overview_l7$new_ID %in% singlbarcoders_ind,"in_study"] = F
   sample_overview_l7[sample_overview_l7$new_ID %in% singlbarcoders_ind,"reason4exclusion"] <- "Batch/effect correction via ComBat not possible - only 1 Ind. with this Sentrix ID"
 

--- a/R/removeBatchEffects.R
+++ b/R/removeBatchEffects.R
@@ -458,8 +458,12 @@ removeBatchEffects = function(ht12object,
   ht12object$genesdetail = genesdetail
 
   # individuenattrib
+
+  sample_overview_l7[!(sample_overview_l7$old_ID %in% good.ids),"in_study"] = F #TAG#
+  sample_overview_l7[!(sample_overview_l7$old_ID %in% good.ids),"reason4exclusion"] <- "Missings in covariate data. This is not allowed with batch adjustment via ComBat()"
   sample_overview_l7[sample_overview_l7$new_ID %in% singlbarcoders_ind,"in_study"] = F
   sample_overview_l7[sample_overview_l7$new_ID %in% singlbarcoders_ind,"reason4exclusion"] <- "Batch/effect correction via ComBat not possible - only 1 Ind. with this Sentrix ID"
+
   mytable(sample_overview_l7$reason4exclusion)
   mytable(sample_overview_l7$in_study)
   ht12object$chipsamples =  sample_overview_l7

--- a/R/removeBatchEffects.R
+++ b/R/removeBatchEffects.R
@@ -459,8 +459,8 @@ removeBatchEffects = function(ht12object,
 
   # individuenattrib
 
-  sample_overview_l7[!(sample_overview_l7$old_ID %in% good.ids),"in_study"] = F #TAG#
-  sample_overview_l7[!(sample_overview_l7$old_ID %in% good.ids),"reason4exclusion"] <- "Missings in covariate data. This is not allowed with batch adjustment via ComBat()"
+  sample_overview_l7[!(sample_overview_l7$new_ID %in% good.ids),"in_study"] = F #TAG#
+  sample_overview_l7[!(sample_overview_l7$new_ID %in% good.ids),"reason4exclusion"] <- "Missings in covariate data. This is not allowed with batch adjustment via ComBat()"
   sample_overview_l7[sample_overview_l7$new_ID %in% singlbarcoders_ind,"in_study"] = F
   sample_overview_l7[sample_overview_l7$new_ID %in% singlbarcoders_ind,"reason4exclusion"] <- "Batch/effect correction via ComBat not possible - only 1 Ind. with this Sentrix ID"
 


### PR DESCRIPTION
These three commits should sort out the issues created by removing individuals from the `$chipsamples` objects due to missings in the covariate data