### PR TITLE
0.0.17

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: HT12ProcessoR
 Type: Package
 Title: Preprocessing Illuminas HT12 v4 data
-Version: 0.0.15
-Date: 2017-07-02
+Version: 0.0.17
+Date: 2019-05-20
 Author: Holger Kirsten and Carl Beuchel
 Maintainer: Holger Kirsten<holger.kirsten@imise.uni-leipzig.de>
 Description: Preprocessing ILLUMINA HT12v4 data intented for project up to thousands of samples

--- a/R/removeBatchEffects.R
+++ b/R/removeBatchEffects.R
@@ -434,7 +434,7 @@
                    Biobase::pData(
                      total_nobkgd_eset_ql
                      )$sampleID %in% good.ids,
-                   ]$sampleID) == F) {
+                   "sampleID"]) == F) {
       stop("Something went wrong - code 33443361")
       }
 
@@ -460,7 +460,7 @@
     ht12object$genesdetail = genesdetail
 
     # individuenattrib
-    sample_overview_l7[sample_overview_l7$in_study & !(sample_overview_l7$new_ID %in% good.ids), ]$reason4exclusion <- "tmp"
+    sample_overview_l7[sample_overview_l7$in_study & !(sample_overview_l7$new_ID %in% good.ids), "reason4exclusion"] <- "tmp"
     sample_overview_l7[!(sample_overview_l7$new_ID %in% good.ids),"in_study"] = F
 
     # don't overwrite the other reason4exclusions


### PR DESCRIPTION
* Restore and Merge latest changes made to removeBatchEffects()

Last commit:

Date: 2019-05-20

* Fix error when writing into "]$reason4exclusion <- ..."  when row call is
empty by changing it to "...[..., 'reason4exclusion'] <- ..."